### PR TITLE
Fix #1: process hyphenated words independently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,16 @@ dependencies = [
  "getopts 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -35,12 +44,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num_cpus"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "regex"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "threadpool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ authors = ["J/A <archer884@gmail.com>"]
 getopts = "*"
 lazy_static = "*"
 num_cpus = "*"
+regex = "*"
 threadpool = "*"

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,9 @@
+use regex::Regex;
 use std::fmt;
+
+lazy_static! {
+    static ref WORD_PATTERN: Regex = Regex::new(r"([A-z]+)('[A-z]+)?\.?").unwrap();
+}
 
 pub struct Line {
     pub number: usize,
@@ -14,12 +19,11 @@ impl Line {
     }
 
     pub fn words(&self) -> Vec<Word> {
-        self.content.split_whitespace()
-            .map(|word| Word {
+        WORD_PATTERN.captures_iter(&self.content)
+            .filter_map(|cap| cap.at(0).map(|content| Word {
                 number: self.number,
-                content: word.trim_matches(|c: char| !c.is_alphabetic()).to_owned(),
-            })
-            .filter(|word| word.content.len() > 0)
+                content: content.to_owned()
+            }))
             .collect()
     }
 }
@@ -32,6 +36,6 @@ pub struct Word {
 
 impl fmt::Display for Word {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Line {:4}: {}", self.number, self.content)
+        write!(f, "Line {:4}: {}", self.number, self.content.trim_right_matches('.'))
     }
 }


### PR DESCRIPTION
Processing using a regular expression (as opposed to splitting on whitespace) allows us to easily handle hyphenated words as individual words.
