### PR TITLE
Fix #1: process hyphenated words independently

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -15,6 +15,7 @@ impl Line {
 
     pub fn words(&self) -> Vec<Word> {
         self.content.split_whitespace()
+            .flat_map(|word| word.split('-'))
             .map(|word| Word {
                 number: self.number,
                 content: word.trim_matches(|c: char| !c.is_alphabetic()).to_owned(),


### PR DESCRIPTION
This inserts a flat_map step that splits on `'-'`before mapping string slices to `Word` structs. Seems to be cheaper than regular expressions.
