### PR TITLE
Swap to scoped_threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = "0.1.0"
 dependencies = [
  "getopts 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped_threadpool 0.1.2 (git+https://github.com/Kimundi/scoped-threadpool-rs)",
 ]
 
 [[package]]
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+name = "scoped_threadpool"
+version = "0.1.2"
+source = "git+https://github.com/Kimundi/scoped-threadpool-rs#65659ea9d62eed5d9d51be7bc0d9be542dc48392"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,6 @@ authors = ["J/A <archer884@gmail.com>"]
 [dependencies]
 getopts = "*"
 num_cpus = "*"
-threadpool = "*"
+
+[dependencies.scoped_threadpool]
+git = "https://github.com/Kimundi/scoped-threadpool-rs"


### PR DESCRIPTION
Scoped threadpool has been shown in testing to have very slightly better performance characteristics than `Arc` cloning, probably due to the (minimal) cost of cloning itself.
